### PR TITLE
Fix: graph is created again during the drop process

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/ConfiguredGraphFactory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/ConfiguredGraphFactory.java
@@ -155,10 +155,16 @@ public class ConfiguredGraphFactory {
      * @throws BackendException If an error occurs during deletion
      * @throws ConfigurationManagementGraphNotEnabledException If ConfigurationManagementGraph not
      */
-    public static void drop(String graphName) throws Exception {
-        final StandardJanusGraph graph = (StandardJanusGraph) ConfiguredGraphFactory.close(graphName);
+    public static void drop(String graphName) throws BackendException, ConfigurationManagementGraphNotEnabledException, Exception {
+        final ConfigurationManagementGraph configManagementGraph = getConfigGraphManagementInstance();
+        configManagementGraph.removeConfiguration(graphName);
+
+        final JanusGraphManager jgm = JanusGraphManagerUtility.getInstance();
+        Preconditions.checkNotNull(jgm, JANUS_GRAPH_MANAGER_EXPECTED_STATE_MSG);
+
+        final StandardJanusGraph graph = (StandardJanusGraph) jgm.getGraph(graphName);
+        removeGraphFromCache(graph);
         JanusGraphFactory.drop(graph);
-        removeConfiguration(graphName);
     }
 
     private static ConfigurationManagementGraph getConfigGraphManagementInstance() {

--- a/janusgraph-test/src/test/java/org/janusgraph/core/ConfiguredGraphFactoryTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/core/ConfiguredGraphFactoryTest.java
@@ -28,6 +28,7 @@ import org.apache.commons.configuration.MapConfiguration;
 
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
@@ -216,6 +217,25 @@ public class ConfiguredGraphFactoryTest {
 
             ConfiguredGraphFactory.removeConfiguration("graph1");
             assertNull(gm.getGraph("graph1"));
+        } finally {
+            ConfiguredGraphFactory.removeConfiguration("graph1");
+            ConfiguredGraphFactory.close("graph1");
+        }
+    }
+
+    @Test
+    public void dropGraphShouldRemoveGraphFromCache() throws Exception {
+        try {
+            final Map<String, Object> map = new HashMap<>();
+            map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
+            map.put(GRAPH_NAME.toStringWithoutRoot(), "graph1");
+            ConfiguredGraphFactory.createConfiguration(new MapConfiguration(map));
+            final StandardJanusGraph graph = (StandardJanusGraph) ConfiguredGraphFactory.open("graph1");
+            assertNotNull(graph);
+
+            ConfiguredGraphFactory.drop("graph1");
+            assertNull(gm.getGraph("graph1"));
+            assertTrue(graph.isClosed());
         } finally {
             ConfiguredGraphFactory.removeConfiguration("graph1");
             ConfiguredGraphFactory.close("graph1");


### PR DESCRIPTION
This PR address issue #2147 by refactoring the `drop()` method in the `ConfiguredGraphFactory` class.

The bug was in the call to `removeGraphFromCache(String graphName)` which internally try to open the graph. Because of the order of the calls, the graph was already dropped by a call to `JanusGraphFactory.drop(graph)` which then result in the storage to be recreated.



-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there an issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

